### PR TITLE
Backend SignalR changes for collaborative editor

### DIFF
--- a/src/TopoMojo.Abstractions/Models/Document.cs
+++ b/src/TopoMojo.Abstractions/Models/Document.cs
@@ -9,5 +9,6 @@ namespace TopoMojo.Models
     {
         public string Text { get; set; }
         public string WhenSaved { get; set; }
+        public string Timestamp { get; set; }
     }
 }

--- a/src/TopoMojo.Abstractions/Models/Document.cs
+++ b/src/TopoMojo.Abstractions/Models/Document.cs
@@ -1,0 +1,13 @@
+// Copyright 2020 Carnegie Mellon University. All Rights Reserved.
+// Released under a 3 Clause BSD-style license. See LICENSE.md in the project root for license information.
+
+using System;
+
+namespace TopoMojo.Models
+{
+    public class Document
+    {
+        public string Text { get; set; }
+        public string WhenSaved { get; set; }
+    }
+}

--- a/src/TopoMojo.Web/Controllers/DocumentController.cs
+++ b/src/TopoMojo.Web/Controllers/DocumentController.cs
@@ -58,7 +58,7 @@ namespace TopoMojo.Web.Controllers
             System.IO.File.WriteAllText(path, text);
             
             if (fromTyping)
-                SendBroadcast(id, "saved", text);
+                SendBroadcast($"{id}-doc", "saved", text);
 
             return Ok();
         }

--- a/src/TopoMojo.Web/Controllers/DocumentController.cs
+++ b/src/TopoMojo.Web/Controllers/DocumentController.cs
@@ -44,10 +44,9 @@ namespace TopoMojo.Web.Controllers
         /// </summary>
         /// <param name="id">Workspace Id</param>
         /// <param name="text">Markdown text</param>
-        /// <param name="fromTyping">Cause of save was automatic from user typing</param>
         /// <returns></returns>
         [HttpPut("api/document/{id}")]
-        public async Task<ActionResult> Save(string id, [FromBody]string text, bool fromTyping = false)
+        public async Task<ActionResult> Save(string id, [FromBody]string text)
         {
             if (!await _workspaceService.CanEdit(id))
                 return Forbid();
@@ -57,7 +56,6 @@ namespace TopoMojo.Web.Controllers
             path = System.IO.Path.Combine(path, id + ".md");
             System.IO.File.WriteAllText(path, text);
             
-            if (fromTyping)
                 SendBroadcast($"{id}-doc", "saved", text);
 
             return Ok();

--- a/src/TopoMojo.Web/Controllers/DocumentController.cs
+++ b/src/TopoMojo.Web/Controllers/DocumentController.cs
@@ -149,6 +149,7 @@ namespace TopoMojo.Web.Controllers
 
         private void SendBroadcast(string roomId, string action, string text)
         {
+            DateTime currentDatetime = DateTime.UtcNow;
             _hub.Clients
                 .Group(roomId)
                 .DocumentEvent(
@@ -157,7 +158,8 @@ namespace TopoMojo.Web.Controllers
                         "DOCUMENT." + action.ToUpper(),
                         new Document {
                             Text = text,
-                            WhenSaved = DateTime.UtcNow.ToString("u")
+                            WhenSaved = currentDatetime.ToString("u"),
+                            Timestamp = currentDatetime.ToString("ss.ffff")
                         }
                     )
                 );

--- a/src/TopoMojo.Web/Controllers/Hubs/TopoHub.cs
+++ b/src/TopoMojo.Web/Controllers/Hubs/TopoHub.cs
@@ -84,6 +84,21 @@ namespace TopoMojo.Web.Controllers
             return Clients.OthersInGroup(model.WorkspaceGlobalId).TemplateEvent(new BroadcastEvent<Template>(Context.User, action, model));
         }
 
+        public Task Edited(string channelId, object textDiff)
+        {
+            return Clients.OthersInGroup(channelId).DocumentEvent(new BroadcastEvent<object>(Context.User, "DOCUMENT.UPDATED", textDiff));
+        }
+
+        public Task CursorChanged(string channelId, object positions)
+        {
+            return Clients.OthersInGroup(channelId).DocumentEvent(new BroadcastEvent<object>(Context.User, "DOCUMENT.CURSOR", positions));
+        }
+
+        public Task Editing(string channelId, bool val)
+        {
+            return Clients.OthersInGroup(channelId).DocumentEvent(new BroadcastEvent<Document>(Context.User, (val) ? "DOCUMENT.TYPING" : "DOCUMENT.IDLE", null));
+        }
+
     }
 
     public interface ITopoEvent
@@ -92,6 +107,8 @@ namespace TopoMojo.Web.Controllers
         Task TopoEvent(BroadcastEvent<Workspace> broadcastEvent);
         Task TemplateEvent(BroadcastEvent<Template> broadcastEvent);
         Task ChatEvent(BroadcastEvent<Message> broadcastEvent);
+        Task DocumentEvent(BroadcastEvent<object> broadcastEvent);
+        Task DocumentEvent(BroadcastEvent<Document> broadcastEvent);
         Task VmEvent(BroadcastEvent<VmState> broadcastEvent);
         Task PresenceEvent(BroadcastEvent broadcastEvent);
         Task GameEvent(BroadcastEvent<GameState> broadcastEvent);
@@ -138,7 +155,7 @@ namespace TopoMojo.Web.Controllers
             return new Actor
             {
                 Id = ((ClaimsPrincipal)user).FindFirstValue(JwtRegisteredClaimNames.Sub),
-                Name = user.Identity.Name
+                Name = ((ClaimsPrincipal)user).FindFirstValue("name")
             };
         }
     }


### PR DESCRIPTION
Goes with PR (https://github.com/cmu-sei/topomojo-ui/pull/10)

- Create three new SignalR endpoints:
   - typing events (e.g. user stopped typing)
   - content changes (e.g. new text added to doc)
   - cursor changes (e.g. user moves cursor)

- Also have the document save() API endpoint send the saved document with SignalR to all clients to try to synchronize if needed.